### PR TITLE
Add RTSP video stream support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,9 @@ action:
 
 ## 🚧 Limitations
 
-- **Live video streaming** is not yet supported inside Home Assistant.  
-  The HP7 uses temporary tickets and relay servers, which are still under investigation.
+- **Live video streaming** uses the local RTSP feed of the HP7. The device must be
+  reachable on your network and the integration needs to obtain the verification code
+  from EZVIZ.
 - The integration currently supports **one HP7 device per account** (multi-device support planned).
 
 ---

--- a/custom_components/ezviz_hp7/api.py
+++ b/custom_components/ezviz_hp7/api.py
@@ -110,10 +110,23 @@ class Hp7Api:
             return {}
         try:
             data = json.loads(out)
-            return data if isinstance(data, dict) else {}
+            if not isinstance(data, dict):
+                data = {}
         except Exception as e:
             _LOGGER.error("Parse JSON status fallito: %s", e)
-            return {}
+            data = {}
+
+        if data:
+            # Prova a recuperare il codice di verifica per lo streaming RTSP.
+            try:
+                self.ensure_client()
+                auth = self._client.get_cam_auth_code(serial)
+                if isinstance(auth, dict) and auth.get("devAuthCode"):
+                    data["rtsp_password"] = auth["devAuthCode"]
+            except Exception as e:  # noqa: BLE001 - meglio non interrompere lo status
+                _LOGGER.debug("get_cam_auth_code fallita: %s", e)
+
+        return data
 
     # -------------------- Sblocco --------------------
 

--- a/custom_components/ezviz_hp7/camera.py
+++ b/custom_components/ezviz_hp7/camera.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from homeassistant.components.camera import Camera
+from homeassistant.components.camera import Camera, CameraEntityFeature
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.helpers.entity import DeviceInfo
@@ -21,6 +21,7 @@ class Hp7LastSnapshotCamera(CoordinatorEntity, Camera):
         self._serial = serial
         self._attr_name = "Ultima Istantanea"
         self._attr_unique_id = f"{DOMAIN}_{serial}_last_snapshot"
+        self._attr_supported_features = CameraEntityFeature.STREAM
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -58,4 +59,14 @@ class Hp7LastSnapshotCamera(CoordinatorEntity, Camera):
         except Exception:
             return None
 
+        return None
+
+    async def stream_source(self) -> str | None:
+        """Restituisce l'URL RTSP per lo streaming live."""
+        data = self.coordinator.data or {}
+        ip = data.get("local_ip")
+        port = data.get("local_rtsp_port") or "554"
+        password = data.get("rtsp_password")
+        if ip and password:
+            return f"rtsp://admin:{password}@{ip}:{port}/Streaming/Channels/101/"
         return None


### PR DESCRIPTION
## Summary
- add retrieval of device verification code to build RTSP URL
- expose RTSP stream in camera entity and mark stream capability
- document RTSP streaming limitations

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68baccadb8a88329bd892237414a5a99