### PR TITLE
Add RTSP video stream support and CP7 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# Home Assistant Integration for EZVIZ HP7 Intercom
+# Home Assistant Integration for EZVIZ HP7/CP7 Intercom
 
-This is a **custom Home Assistant integration** that adds support for the **EZVIZ HP7 video intercom**.  
-It allows you to **unlock the door and the gate remotely**, monitor device status, and expose the main functions of the HP7 within your Home Assistant environment.
+This is a **custom Home Assistant integration** that adds support for the **EZVIZ HP7 and CP7 video intercoms**.
+It allows you to **unlock the door and the gate remotely**, monitor device status, and expose the main functions of the device within your Home Assistant environment.
 
 DO NOT USE THIS INTEGRATION AND THE OFFICIAL ONE TOGETHER (it may not open the door) https://www.home-assistant.io/integrations/ezviz/
 ---
 
 ## ✨ Features
 
-- Discover and register your EZVIZ HP7 device automatically.
+- Discover and register your EZVIZ HP7 or CP7 device automatically.
 - Control:
   - 🔑 Unlock **door** (lock #2 by default).
   - 🚪 Unlock **gate** (lock #1 by default).
@@ -37,20 +37,20 @@ DO NOT USE THIS INTEGRATION AND THE OFFICIAL ONE TOGETHER (it may not open the d
 ## ⚙️ Configuration
 
 1. In Home Assistant, go to **Settings → Devices & Services → Add Integration**.
-2. Search for **EZVIZ HP7**.
+2. Search for **EZVIZ HP7/CP7**.
 3. Enter your **EZVIZ account credentials**:
    - **Username** (email used for EZVIZ app login).
    - **Password**.
    - **Region** (usually `eu` for Europe, `us` for North America).
 
-The integration will log in through the EZVIZ API and automatically detect your HP7 device.
+The integration will log in through the EZVIZ API and automatically detect your HP7 or CP7 device.
 
 ---
 
 ## 🛠 Usage
 
 Once set up, you will see:
-- A device card for your **EZVIZ HP7 intercom**.
+- A device card for your **EZVIZ HP7/CP7 intercom**.
 - Two services exposed:
   - `ezviz_hp7.unlock_door`
   - `ezviz_hp7.unlock_gate`
@@ -74,9 +74,10 @@ action:
 
 ## 🚧 Limitations
 
-- **Live video streaming** is not yet supported inside Home Assistant.  
-  The HP7 uses temporary tickets and relay servers, which are still under investigation.
-- The integration currently supports **one HP7 device per account** (multi-device support planned).
+- **Live video streaming** uses the local RTSP feed of the device. The device must be
+  reachable on your network and the integration needs to obtain the verification code
+  from EZVIZ.
+- The integration currently supports **one device per account** (multi-device support planned).
 
 ---
 

--- a/custom_components/ezviz_hp7/api.py
+++ b/custom_components/ezviz_hp7/api.py
@@ -26,6 +26,8 @@ class Hp7Api:
 
         self.supports_door = True
         self.supports_gate = True
+        # Modello del dispositivo (HP7/CP7). Default a HP7 finché non rilevato.
+        self.model: str = "HP7"
 
     # -------------------- Sessione SDK (solo per unlock) --------------------
 
@@ -38,7 +40,7 @@ class Hp7Api:
             url=self._region_or_url,
         )
         self._client.login()
-        _LOGGER.info("EZVIZ HP7: login OK su %s", self._client._token.get("api_url"))
+        _LOGGER.info("EZVIZ: login OK su %s", self._client._token.get("api_url"))
 
     def login(self) -> bool:
         """Compat per il setup: inizializza il client SDK."""
@@ -52,7 +54,20 @@ class Hp7Api:
             dev = self._client.get_device_infos(serial)
             cat = dev.get("deviceInfos", {}).get("deviceCategory")
             sub = dev.get("deviceInfos", {}).get("deviceSubCategory")
-            _LOGGER.info("EZVIZ HP7: device %s category=%s sub=%s", serial, cat, sub)
+            model = (
+                dev.get("deviceInfos", {}).get("deviceModel")
+                or dev.get("deviceInfos", {}).get("deviceName")
+                or sub
+                or "HP7"
+            )
+            self.model = str(model)
+            _LOGGER.info(
+                "EZVIZ %s: device %s category=%s sub=%s",
+                self.model,
+                serial,
+                cat,
+                sub,
+            )
         except Exception as e:
             _LOGGER.debug("detect_capabilities get_device_infos fallita: %s", e)
         self.supports_door = True
@@ -110,10 +125,23 @@ class Hp7Api:
             return {}
         try:
             data = json.loads(out)
-            return data if isinstance(data, dict) else {}
+            if not isinstance(data, dict):
+                data = {}
         except Exception as e:
             _LOGGER.error("Parse JSON status fallito: %s", e)
-            return {}
+            data = {}
+
+        if data:
+            # Prova a recuperare il codice di verifica per lo streaming RTSP.
+            try:
+                self.ensure_client()
+                auth = self._client.get_cam_auth_code(serial)
+                if isinstance(auth, dict) and auth.get("devAuthCode"):
+                    data["rtsp_password"] = auth["devAuthCode"]
+            except Exception as e:  # noqa: BLE001 - meglio non interrompere lo status
+                _LOGGER.debug("get_cam_auth_code fallita: %s", e)
+
+        return data
 
     # -------------------- Sblocco --------------------
 

--- a/custom_components/ezviz_hp7/binary_sensor.py
+++ b/custom_components/ezviz_hp7/binary_sensor.py
@@ -49,9 +49,10 @@ class Hp7Binary(CoordinatorEntity, BinarySensorEntity):
 
     @property
     def device_info(self) -> DeviceInfo:
+        model = getattr(self.coordinator.api, "model", "HP7")
         return DeviceInfo(
             identifiers={(DOMAIN, self._serial)},
-            name=f"EZVIZ HP7 ({self._serial})",
+            name=f"EZVIZ {model} ({self._serial})",
             manufacturer="EZVIZ",
-            model="HP7",
+            model=model,
         )

--- a/custom_components/ezviz_hp7/button.py
+++ b/custom_components/ezviz_hp7/button.py
@@ -29,18 +29,30 @@ class EzvizHp7Button(ButtonEntity):
 
     @property
     def device_info(self) -> DeviceInfo:
+        model = getattr(self._api, "model", "HP7")
         return DeviceInfo(
             identifiers={(DOMAIN, self._serial)},
-            name=f"EZVIZ HP7 ({self._serial})",
+            name=f"EZVIZ {model} ({self._serial})",
             manufacturer="EZVIZ",
-            model="HP7",
+            model=model,
         )
 
     async def async_press(self) -> None:
-        _LOGGER.warning("EZVIZ HP7: premuto bottone '%s' (%s)", self._action, self._serial)
+        model = getattr(self._api, "model", "HP7")
+        _LOGGER.warning("EZVIZ %s: premuto bottone '%s' (%s)", model, self._action, self._serial)
         if self._action == "unlock_gate":
             ok = await self.hass.async_add_executor_job(self._api.unlock_gate, self._serial)
-            _LOGGER.log(logging.INFO if ok else logging.ERROR, "EZVIZ HP7: 'Sblocca Cancello' %s.", "OK" if ok else "FALLITO")
+            _LOGGER.log(
+                logging.INFO if ok else logging.ERROR,
+                "EZVIZ %s: 'Sblocca Cancello' %s.",
+                model,
+                "OK" if ok else "FALLITO",
+            )
         elif self._action == "unlock_door":
             ok = await self.hass.async_add_executor_job(self._api.unlock_door, self._serial)
-            _LOGGER.log(logging.INFO if ok else logging.ERROR, "EZVIZ HP7: 'Sblocca Porta' %s.", "OK" if ok else "FALLITO")
+            _LOGGER.log(
+                logging.INFO if ok else logging.ERROR,
+                "EZVIZ %s: 'Sblocca Porta' %s.",
+                model,
+                "OK" if ok else "FALLITO",
+            )

--- a/custom_components/ezviz_hp7/camera.py
+++ b/custom_components/ezviz_hp7/camera.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from homeassistant.components.camera import Camera
+from homeassistant.components.camera import Camera, CameraEntityFeature
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.helpers.entity import DeviceInfo
@@ -21,14 +21,16 @@ class Hp7LastSnapshotCamera(CoordinatorEntity, Camera):
         self._serial = serial
         self._attr_name = "Ultima Istantanea"
         self._attr_unique_id = f"{DOMAIN}_{serial}_last_snapshot"
+        self._attr_supported_features = CameraEntityFeature.STREAM
 
     @property
     def device_info(self) -> DeviceInfo:
+        model = getattr(self.coordinator.api, "model", "HP7")
         return DeviceInfo(
             identifiers={(DOMAIN, self._serial)},
-            name=f"EZVIZ HP7 ({self._serial})",
+            name=f"EZVIZ {model} ({self._serial})",
             manufacturer="EZVIZ",
-            model="HP7",
+            model=model,
         )
 
     async def async_camera_image(self, width: int | None = None, height: int | None = None):
@@ -58,4 +60,14 @@ class Hp7LastSnapshotCamera(CoordinatorEntity, Camera):
         except Exception:
             return None
 
+        return None
+
+    async def stream_source(self) -> str | None:
+        """Restituisce l'URL RTSP per lo streaming live."""
+        data = self.coordinator.data or {}
+        ip = data.get("local_ip")
+        port = data.get("local_rtsp_port") or "554"
+        password = data.get("rtsp_password")
+        if ip and password:
+            return f"rtsp://admin:{password}@{ip}:{port}/Streaming/Channels/101/"
         return None

--- a/custom_components/ezviz_hp7/coordinator.py
+++ b/custom_components/ezviz_hp7/coordinator.py
@@ -11,7 +11,7 @@ class Hp7Coordinator(DataUpdateCoordinator):
         super().__init__(
             hass,
             _LOGGER,
-            name="EZVIZ HP7",
+            name=f"EZVIZ {getattr(api, 'model', 'HP7')}",
             update_interval=timedelta(seconds=UPDATE_INTERVAL_SEC),
         )
         self.api = api

--- a/custom_components/ezviz_hp7/manifest.json
+++ b/custom_components/ezviz_hp7/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "ezviz_hp7",
-  "name": "EZVIZ HP7",
+  "name": "EZVIZ HP7/CP7",
   "codeowners": ["@Bobsilvio"],
   "config_flow": true,
   "dependencies": [],

--- a/custom_components/ezviz_hp7/sensor.py
+++ b/custom_components/ezviz_hp7/sensor.py
@@ -60,11 +60,12 @@ class Hp7Sensor(CoordinatorEntity, SensorEntity):
 
     @property
     def device_info(self) -> DeviceInfo:
+        model = getattr(self.coordinator.api, "model", "HP7")
         return DeviceInfo(
             identifiers={(DOMAIN, self._serial)},
-            name=f"EZVIZ HP7 ({self._serial})",
+            name=f"EZVIZ {model} ({self._serial})",
             manufacturer="EZVIZ",
-            model="HP7",
+            model=model,
         )
 
     @property

--- a/custom_components/ezviz_hp7/translations/strings.json
+++ b/custom_components/ezviz_hp7/translations/strings.json
@@ -2,12 +2,12 @@
   "config": {
     "step": {
       "user": {
-        "title": "Collega EZVIZ HP7",
+        "title": "Collega EZVIZ HP7/CP7",
         "description": "Inserisci le credenziali EZVIZ e la regione."
       },
       "pick_serial": {
         "title": "Seleziona dispositivo",
-        "description": "Scegli il serial del tuo HP7."
+        "description": "Scegli il serial del tuo HP7 o CP7."
       }
     },
     "error": {


### PR DESCRIPTION
## Summary
- add retrieval of device verification code to build RTSP URL
- expose RTSP stream in camera entity and mark stream capability
- document RTSP streaming limitations
- auto-detect model to support HP7 and CP7 devices
- update naming, manifest and translations for HP7/CP7

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68baccadb8a88329bd892237414a5a99